### PR TITLE
ds3231_set_esp_with_rtc() fix

### DIFF
--- a/esp-idf-ds3231.c
+++ b/esp-idf-ds3231.c
@@ -326,7 +326,7 @@ esp_err_t ds3231_time_time_t_set(rtc_handle_t* rtc_handle, time_t time) {
 }
 
 int ds3231_set_esp_with_rtc(rtc_handle_t* rtc_handle) {
-    struct timeval rtc_time = {.tv_sec = 0, .tv_usec = 0};
+    struct timeval rtc_time = {0};
     rtc_time.tv_sec = ds3231_time_unix_get(rtc_handle);
     return settimeofday(&rtc_time, NULL);
 }

--- a/esp-idf-ds3231.c
+++ b/esp-idf-ds3231.c
@@ -326,7 +326,7 @@ esp_err_t ds3231_time_time_t_set(rtc_handle_t* rtc_handle, time_t time) {
 }
 
 int ds3231_set_esp_with_rtc(rtc_handle_t* rtc_handle) {
-    struct timeval rtc_time;
+    struct timeval rtc_time = {.tv_sec = 0, .tv_usec = 0};
     rtc_time.tv_sec = ds3231_time_unix_get(rtc_handle);
     return settimeofday(&rtc_time, NULL);
 }


### PR DESCRIPTION
During my work with ESP32 I noticed that if I use library function ds3231_set_esp_with_rtc() there is a positive time offset (about 18 minutes) in time value that set in EPS32 (not in time stored in DS3231). 
But if I tried to set time of ESP32 manually (getting time value from DS3231 and using settimeofday() with allocating corresponding variables) there was no offset. Comparing both approaches, I came to the conclusion that there is lack of initialization of the fields in the timeval structure. After adding initialization the problem disappeared. This sould be undefined behaviour while settimeofday() using not initialized/allocated struct tv_usec field. Not sure about this happening in all versions and optimization levels (I`m using ESP-IDF v1.11.0 and -Od flag).

To reproduce, use in code something like:
```
    char strftime_buf[64];
    struct tm timeinfo;
    time_t now = ds3231_time_unix_get(rtc_handle);
    localtime_r(&now, &timeinfo);
    strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
    printf("The current time from the DS3231 RTC module is: %s\n", strftime_buf);

    ds3231_set_esp_with_rtc(rtc_handle);

    time(&now);
    localtime_r(&now, &timeinfo);
    strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
    printf("The current ESP32 time is: %s\n", strftime_buf);
```

Output before adding struct initialization:

> The current time from the DS3231 RTC module is: Sat Jan 10 15:36:05 2026
> The current ESP32 time is: Sat Jan 10 15:53:58 2026

Output after adding initialization:

> The current time from the DS3231 RTC module is: Sat Jan 10 16:21:51 2026
> The current ESP32 time is: Sat Jan 10 16:21:51 2026